### PR TITLE
Bug fix and notification / batching improvements

### DIFF
--- a/MJFastImageLoader/MJFastImageLoader/DataIdentity.swift
+++ b/MJFastImageLoader/MJFastImageLoader/DataIdentity.swift
@@ -50,7 +50,7 @@ class DataIdentity : Equatable, Hashable {
 		let maximumSampleSize = 3200
 		let short = data.count < maximumSampleSize
 		let partial1Start = short ? 1 : (data.count / 100 * 50)
-		var partial1End = short ? data.count : (data.count / 100 * 51)
+		var partial1End = short ? (data.count - 1) : (data.count / 100 * 51)
 		if ( partial1End - partial1Start > maximumSampleSize ) {
 			partial1End = partial1Start + maximumSampleSize - 1
 		}
@@ -70,7 +70,7 @@ class DataIdentity : Equatable, Hashable {
 
 		// If the data is small, use all except the first two bytes for the secondary hash.  Otherwise use a early-ish one tenth of the data.
 		let partial2Start = short ? 1 : (data.count / 100 * 20)
-		var partial2End = short ? data.count : (data.count / 100 * 21)
+		var partial2End = short ? (data.count - 1) : (data.count / 100 * 21)
 		if ( partial2End - partial2Start > maximumSampleSize ) {
 			partial2End = partial2Start + maximumSampleSize - 1
 		}

--- a/MJFastImageLoader/MJFastImageLoader/FastImageLoader.swift
+++ b/MJFastImageLoader/MJFastImageLoader/FastImageLoader.swift
@@ -311,8 +311,11 @@ public class FastImageLoader {
 	/// - Parameters:
 	///   - image: The image to retrieve render for.
 	///   - notification: The notification to register with that image.
+	///   - notifyImmediateIfAvailable: If true, and there is a non-nil image to return, also push a notification in case it is fully rendered.
 	/// - Returns: Rendered image.
-	public func image(image: Data, notification: FastImageLoaderNotification?) -> UIImage? {
+	public func image(image: Data,
+					  notification: FastImageLoaderNotification?,
+					  notifyImmediateIfAvailable: Bool) -> UIImage? {
 		// Turn the large Data into a small DataIdentity.
 		let identity = DataIdentity(data: image)
 
@@ -349,7 +352,13 @@ public class FastImageLoader {
 
 			if let max = item.results.keys.max() {
 				// If there is a maximum key, then we have an image we can provide.
-				return item.results[max]
+				if let image = item.results[max] {
+					if ( notifyImmediateIfAvailable ) {
+						notification?.queueNotifyEvent(image: image)
+					}
+
+					return image
+				}
 			}
 		}
 

--- a/MJFastImageLoader/MJFastImageLoader/FastImageLoaderBatch.swift
+++ b/MJFastImageLoader/MJFastImageLoader/FastImageLoaderBatch.swift
@@ -59,9 +59,7 @@ open class FastImageLoaderBatch {
 	// MARK: - Private Variables and Execution
 
 	/// The queued notifications.
-	private var notifications:[FastImageLoaderNotification] = []
-	/// The images for the queued notifications.
-	private var images:[UIImage] = []
+	private var batchItems:[FastImageLoaderBatchItem] = []
 	/// The GCD queue providing serialized accumulation.
 	private let queue = DispatchQueue(label: "FastImageLoaderBatch.queue")
 	/// The dispatch work item that will ensure the time limit.
@@ -73,14 +71,14 @@ open class FastImageLoaderBatch {
 		// TODO: This isn't blocking a UI thread, but it would still be good to evalute sync vs async for this method.
 		queue.sync {
 			// Check if we already have a pending image for that notification.
-			if let index = notifications.index(of: notification) {
+			if let item = batchItems.first(where: {$0.notification == notification}) {
 				// We do, so update the image.
-				images[index] = image
+				item.image = image
 			}
 			else {
 				// We don't, so add one and its image.
-				notifications.append(notification)
-				images.append(image)
+				batchItems.append(FastImageLoaderBatchItem(notification: notification,
+														   image: image))
 			}
 		}
 
@@ -92,8 +90,8 @@ open class FastImageLoaderBatch {
 		queue.sync {
 			// Count how many non-cancelled notifications we have.  Ignore cancelled since nobody cares about them.
 			var nonCancelledCount = 0
-			for i in 0..<notifications.count {
-				if ( !notifications[i].cancelled ) {
+			for i in 0..<batchItems.count {
+				if ( !batchItems[i].notification.cancelled ) {
 					nonCancelledCount += 1
 				}
 			}
@@ -101,14 +99,14 @@ open class FastImageLoaderBatch {
 			if ( nonCancelledCount > 0 ) {
 				// See what we should do.
 				let first = 1 == nonCancelledCount
-				let hitQuota = nonCancelledCount >= batchUpdateQuantityLimit
+				let hitCountLimit = nonCancelledCount >= batchUpdateQuantityLimit
 				if ( first ) {
 					// In case the previous timer were still running for content that had all been cancelled.
 					timeLimitWorkItem?.cancel()
 					timeLimitWorkItem = nil
 				}
-				if ( first || hitQuota ) {
-					let timeout:Double = hitQuota ? 0.0 : batchUpdateTimeLimit
+				if ( first || hitCountLimit ) {
+					let timeout:Double = hitCountLimit ? 0.0 : batchUpdateTimeLimit
 
 					// Cancel the previous timeLimitWorkItem if there were one.
 					timeLimitWorkItem?.cancel()
@@ -116,22 +114,41 @@ open class FastImageLoaderBatch {
 					// Create work item to do after timeout.
 					timeLimitWorkItem = DispatchWorkItem {
 						// Cancel the timeout, if there were one
+						let timeLimitWorkItem = self.timeLimitWorkItem
 						self.timeLimitWorkItem?.cancel()
 						self.timeLimitWorkItem = nil
 
-						DLog("notify \(self.notifications.count) for \(hitQuota ? "quota" : "timeout")")
+						if ( !hitCountLimit ) {
+							let now = Date()
+							if nil == self.batchItems.first(where: {!$0.notification.cancelled && $0.earliestTimestamp + self.batchUpdateTimeLimit <= now}) {
+								// We did not find anything that was due at or before now and is not cancelled.  So nothing is actually due yet.  See if we can requeue or clear the list.
+
+								if let item = self.batchItems.first(where: {!$0.notification.cancelled}) {
+									// Requeue for updated timeout.
+									let alreadyPassedTime = Date().timeIntervalSince(item.earliestTimestamp)
+									self.timeLimitWorkItem = timeLimitWorkItem
+									self.queue.asyncAfter(deadline: .now() + timeout - alreadyPassedTime, execute: timeLimitWorkItem!)
+
+								}
+								else {
+									// Everything must be cancelled now, so just remove them and return.
+									self.batchItems = []
+									return
+								}
+							}
+						}
+
+						DLog("notify \(nonCancelledCount) for \(hitCountLimit ? "count" : "timeout")")
 
 						// Do our queued work
 						DispatchQueue.main.sync {
 							// Use the main queue so that batches will draw as one.  Yes, this matters.
-							for i in 0..<self.notifications.count {
-								if ( !self.notifications[i].cancelled ) {
-									self.notifications[i].notify(image: self.images[i])
-								}
-							}
+							self.batchItems.forEach({ (item) in
+								if ( !item.notification.cancelled ) {
+									item.notification.notify(image: item.image)								}
+							})
 						}
-						self.notifications = []
-						self.images = []
+						self.batchItems = []
 					}
 
 					// Submit work item to be done.
@@ -139,5 +156,23 @@ open class FastImageLoaderBatch {
 				}
 			}
 		}
+	}
+}
+
+/// A simple collection of data to track notifications in the batch and what they are notified for.  Prevents having a multitude of arrays.
+// TODO: Evaluate the benefits of class vs struct for this.
+open class FastImageLoaderBatchItem {
+	/// The notification this item is for.
+	public let notification:FastImageLoaderNotification
+	/// The latest image for this notification.  Could be updated if additional renders happen before batch completion.
+	public var image:UIImage
+	/// The date at which this item joined that batch.  Will not be changed by additional renders since the display may still show no image.
+	public let earliestTimestamp:Date
+
+	public init( notification:FastImageLoaderNotification,
+				 image:UIImage ) {
+		self.notification = notification
+		self.image = image
+		earliestTimestamp = Date()
 	}
 }

--- a/MJFastImageLoader/MJFastImageLoaderTests/MJFastImageLoaderTests.swift
+++ b/MJFastImageLoader/MJFastImageLoaderTests/MJFastImageLoaderTests.swift
@@ -319,6 +319,12 @@ class FastImageLoaderTests: XCTestCase {
 			}
 		}
 	}
+
+	func testDataIdentitySmallCount() {
+		let smallImage = UIImageJPEGRepresentation(UIImage(color: UIColor.blue, size: CGSize(width: 30,height: 40))!, 0)!
+
+		_ = DataIdentity(data: smallImage)
+	}
     
     func testDataIdentityPerformance() {
         // This is an example of a performance test case.

--- a/Research/MJFastImageLoaderDemo/MJFastImageLoaderDemo/ViewController.swift
+++ b/Research/MJFastImageLoaderDemo/MJFastImageLoaderDemo/ViewController.swift
@@ -492,11 +492,13 @@ class ViewController: UIViewController {
 			}
 
 			if ( 0 == self.imageDatas.count ) {
-				self.statusLabel.text = "Downloading images..."
-				if let url = URL(string: "https://picsum.photos/5000/3000/?random") {
+				DispatchQueue.main.sync {
+					self.statusLabel.text = "Downloading images..."
 					self.imageViews.forEach({ (imgView) in
 						imgView.contentMode = .scaleAspectFit
 					})
+				}
+				if let url = URL(string: "https://picsum.photos/5000/3000/?random") {
 					self.testQueue.async {
 						let imageCount = 10
 						for i in 1...imageCount {

--- a/Research/MJFastImageLoaderDemo/MJFastImageLoaderDemo/ViewController.swift
+++ b/Research/MJFastImageLoaderDemo/MJFastImageLoaderDemo/ViewController.swift
@@ -361,7 +361,7 @@ class ViewController: UIViewController {
 				let updater = UIImageViewUpdater(imageView: imgView, batch: FastImageLoaderBatch.shared)
 				imageDatasInUse[imageIndex] = data
 				imageUpdaters[imageIndex] = updater
-				imgView.image = FastImageLoader.shared.image(image: data, notification: updater)
+				imgView.image = FastImageLoader.shared.image(image: data, notification: updater, notifyImmediateIfAvailable: false)
 				if ( nil != imgView.image ) {
 					print("non nil image")
 					cacheHits += 1


### PR DESCRIPTION
Fixes an off-by-one error effecting small images.

Adds support for user changing batch quantity limit after things have been added to the batch, allowing a user to say "batch up to 1 item", increment the limit for each item they add, and then decrement at the end of an unknown quantity of images and have the batch notify immediately if that quantity is already available.  Allows for not counting the number of thing that will be batched prior to enqueueing items.

Add mechanism to allow images that are already rendered to participate in a batch for simultaneous display.

Strengthens batch time limit against cancelled items.